### PR TITLE
Bugfix tenant issues

### DIFF
--- a/property-pulse/frontend/src/app/dashboard/issues/page.tsx
+++ b/property-pulse/frontend/src/app/dashboard/issues/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import {useState, useRef, useEffect} from 'react';
 import { useSelector } from 'react-redux';
-import { selectUser } from '@/features/user/userSlice';
+import { selectUser } from '@/features/users/userReducer';
 import { useGetIssuesQuery } from '@/features/issues/tenantIssuesSlice';
 import IssuesForm from "@/components/dashboard/issues/IssuesForm";
 import IssuesList from '@/components/dashboard/issues/IssuesList';

--- a/property-pulse/frontend/src/components/dashboard/issues/IssuesForm.tsx
+++ b/property-pulse/frontend/src/components/dashboard/issues/IssuesForm.tsx
@@ -4,6 +4,7 @@ import {useState} from 'react';
 import { LegacyRef } from "react";
 import ErrorDisplay from "../../ErrorDisplay";
 import { useCreateIssueMutation, useUpdateIssueMutation } from '@/features/issues/tenantIssuesSlice';
+import { getUpdatedObject } from '@/utils/utilityFunctions';
 import { 
 	formOpened,
 	formClosed,
@@ -37,13 +38,15 @@ const IssuesForm = ({issue, isCreate, isOpen, formRef}:{issue:{id:number,type:st
 		}else if(!isCreate){
 			const { type, title, description } = newIssue;
 			const { id } = issue;
-			const editedIssue = {id,type,title,description};
+			let editedIssue:Record<string,any> = { id, type, title, description };
+			//only include any changed values to send to BE. * a value of <""> is "unchanged"
+			//for purposes of edit form.
+			editedIssue = getUpdatedObject(editedIssue)
 			try{
 				await updatedIssue(editedIssue)
 			}
 			catch(error){
-				console.log(error)
-				setError(true)
+				console.log(error);
 			}
 		}
 		form.reset();

--- a/property-pulse/frontend/src/utils/utilityFunctions.ts
+++ b/property-pulse/frontend/src/utils/utilityFunctions.ts
@@ -1,0 +1,18 @@
+// getUpdatedObject takes an object with an arbitrary number of keys with any value type.
+// it returns an object containing only values which aren't equal to <"">
+// * in uncontrolled 'edit' forms this "parses" the object and avoids passing empty vaules to the update.
+const getUpdatedObject = (edit:Record<string, any>): Record<string, any> => {
+	const keys = Object.keys(edit);
+	let updatedObject:Record<string, any> = {};
+	
+	for(let i=0; i<=keys.length-1; i++){
+		const key = keys[i];
+		const value = edit[keys[i]];
+		if(edit[keys[i]] !== ""){
+			updatedObject[keys[i]] = edit[keys[i]];
+		}
+	}
+
+	return updatedObject;
+}
+export { getUpdatedObject };


### PR DESCRIPTION
1. Needed to update 'selectUser' import.
2. If a user submitted an edited form with some fields left unedited, the empty "" value would replace current values. That's fixed now with this merge.